### PR TITLE
Add preliminary clojurescript plumbing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pom.xml.asc
 .lein-failures
 .nrepl-port
 *~
+/resources/public/js/main.js

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,9 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :plugins [[lein-cljsbuild "1.1.6"]]
   :dependencies [[org.clojure/clojure "1.8.0"]
+                 [org.clojure/clojurescript "1.9.521"]
                  [org.clojure/data.json "0.2.6"]
                  [org.clojure/data.csv "0.1.3"]
                  [org.clojure/data.xml "0.0.8"]
@@ -22,6 +24,11 @@
                  [clj-jgit "0.8.9"]
 
                  [com.blazegraph/bigdata-core "2.1.4"]]
+
+  :cljsbuild {:builds [{:source-paths ["src/knode/front_end"]
+                        :compiler {:output-to "resources/public/js/main.js"
+                                   :optimizations :whitespace
+                                   :pretty-print true}}]}
 
   :main knode.cli
   :aot [knode.cli])

--- a/src/knode/front_end/core.cljs
+++ b/src/knode/front_end/core.cljs
@@ -1,0 +1,3 @@
+(ns knode.front-end.core)
+
+(.log js/console "Hello from auto-loading Clojurescript!")

--- a/src/knode/server/template.clj
+++ b/src/knode/server/template.clj
@@ -67,4 +67,5 @@
 
     [:script {:src "/assets/jquery.min.js"}]
     [:script {:src "/assets/bootstrap.min.js"}]
-    [:script {:src "/assets/ie10-viewport-bug-workaround.js"}]]))
+    [:script {:src "/assets/ie10-viewport-bug-workaround.js"}]
+    [:script {:src "/js/main.js"}]]))


### PR DESCRIPTION
- Add cljsbuild to the project file
- Add build info for clojurescript front-end
- Add basic front-end file that logs to console
- Add clojurescript compiler as dependency
- Add js/main.js to the main project template
- Add js/main.js to .gitignore