### PR TITLE
Resources by config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,86 @@
 6. Load your ontology into `knode` state _(if you're setting up an ontology with a `load.txt` file, you can just do `KNODE_PROJECT_DIR=<your project directory> lein run load`. Otherwise, you'll need to pass in the project name and files in the proper order. For instance `lein run load ONTIE ~/ONTIE/ontology/context.kn ~/ONTIE/ontology/external.tsv ~/ONTIE/ontology/predicates.tsv ~/ONTIE/ontology/index.tsv ~/ONTIE/ontology/templates.kn ~/ONTIE/ontology/ontie.kn`)_
 7. `KNODE_SSH_PASSPHRASE=<your key passphrase> KNODE_PROJECT_DIR=<your project dir> lein run serve` _(the first time you run this, it will take a while because new `JAR`s)_
 
+## Configuration Files
+
+You may provide a set of configuration options via an EDN file. By default, this can be `knode.edn` in the same directory that you run `knode` in. In this file, you may specify a number of configurators:
+
+* `:project-name`: name of the project
+* `:project-dir`: directory to house resources and `knode.db` file
+* `:base-iri`: base IRI for ontology (default `http://ontology.iedb.org/ontology/ONTIE_`)
+* `:port`: port to run the server on (default `3210`)
+* `:database-url`: URL to database to store resources and states (default `jdbc:sqlite:<absolute path>/knode.db`)
+* `:git-repo`: path to git repository
+* `:ssh-identity`: SSH identity for git (default `~/.ssh/id_rsa`)
+* `:ssh-passphrase`: SSH passphrase for git
+* `:api-key`
+* `:write-file`
+* `:resources`: see below
+
+To run KnODE from a configuration file (replace `knode.edn` if necessary):
+```
+knode serve knode.edn
+```
+
+To view the configuration settings:
+```
+knode config knode.edn
+```
+
+#### Resources
+
+To load resources from the configuration file (if you are using `knode.edn`, you do not need to specify the path):
+```
+knode load-config
+```
+
+Or:
+```
+knode load-config <path to edn>
+```
+
+Resources should be provided as a vector of individual resources. Each resource needs, minimally:
+
+* `:idspace`
+* `:type`
+
+You may also include:
+
+* `:label` and/or `:title`
+* `:description`
+* `:homepage`
+
+Valid types of resources are:
+
+* `:local-file`: include a `:path` or `:paths` to local resources
+* `:obo-published-owl`: use the `:idspace` to download an OBO published resource (must be the same as the OBO ID)
+* `:direct-link`: include a `:url` to point to the remote resource
+* `:obo-github-repo`: include a `:repo` pointing to a `.git` repository in the standard OBO directory layout
+
+#### Example Config
+
+```
+{:project-name "ONTIE",
+ :resources
+ [{:idspace "ONTIE",
+   :title "Ontology for Immune Epitopes",
+   :description
+   "ONTIE includes a range of terms to support the Immune Epitope Database.",
+   :homepage "https://ontology.iedb.org",
+   :type :local-file,
+   :paths
+   ["ontology/context.kn"
+    "ontology/external.tsv"
+    "ontology/predicates.tsv"
+    "ontology/index.tsv"
+    "ontology/templates.kn"
+    "ontology/ontie.kn"]}
+  {:idspace "OBI",
+   :title "Ontology for Biomedical Investigations",
+   :homepage "http://obi-ontology.org",
+   :type :obo-published-owl}]}
+```
+
 ## License
 
 Copyright © 2017 Knocean Inc.

--- a/src/com/knocean/knode/cli.clj
+++ b/src/com/knocean/knode/cli.clj
@@ -41,7 +41,6 @@
           (println "No '" config "' exists in current directory...")
           (println "\tyou must specify a configuration file")
           (System/exit 1))
-        (println "Woo! Doing the thing!")
         ; Get the configurators from the config file
         (st/init-from-config)
         ; Set up the local resource files

--- a/src/com/knocean/knode/cli.clj
+++ b/src/com/knocean/knode/cli.clj
@@ -11,6 +11,7 @@
 
   knode serve    Serve resources
   knode config   Show configuration
+  knode load-config [config]
   knode load [resource] [files]
   knode db (create|drop) (tables|indexes)
   knode help     Show this help message")
@@ -31,9 +32,13 @@
           (println "\tyou must specify a configuration file")
           (System/exit 1))
         (println "Woo! Doing the thing!")
+        ; Get the configurators from the config file
         (st/init-from-config)
-        (println "Loading resources...")
+        ; Set up the local resource files
+        (println "Retrieving resources...")
         (r/resources! config)
+        ; Load the new resources
+        (println "Loading resources...")
         (doseq [r (:resources @st/state)]
           (loader/load-resource r))
         (System/exit 0))

--- a/src/com/knocean/knode/cli.clj
+++ b/src/com/knocean/knode/cli.clj
@@ -20,10 +20,20 @@
   (let [task (first args)]
     (case task
       "help" (println usage)
-      "config" (do (st/init) (println (st/report @st/state)))
-      "serve" (do (st/init) (server/start))
-      ;"config" (do (st/init-from-config) (println (st/report @st/state)))
-      ;"serve" (do (st/init-from-config) (server/start))
+
+      "config" 
+      (if (not (empty? (rest args)))
+        (do
+          (st/init-from-config)
+          (println (st/report @st/state)))
+        (do (st/init) (println (st/report @st/state))))
+
+      "serve" 
+      (if (not (empty? (rest args)))
+        (do
+          (st/init-from-config)
+          (server/start))
+        (do (st/init) (server/start)))
 
       "load-config"
       (let [config (or (second args) "knode.edn")]

--- a/src/com/knocean/knode/resources.clj
+++ b/src/com/knocean/knode/resources.clj
@@ -38,22 +38,19 @@
 
 (defn insert!
   "Given a resource entry, add the resource to the 'resources' table. If a 
-   resource with the same label (idspace) already exists, remove it and add the 
-   new one."
+   resource with the same label (idspace) already exists, add the states
+   to the existing resource."
   [{:keys [:idspace :label :title :description :homepage] :as resource}]
   (let [res {:label idspace
              :title (or title idspace)
              :description (or description "")
              :homepage (or homepage "")}]
-    ; query to see if resource with same label exists, delete if so
-    (if (empty? (st/query {:select [:*] 
-                           :from [:resources] 
-                           :where [:= :label idspace]}))
-      (jdbc/insert! @st/state :resources res)
-      (do
-        (println "UPDATING" idspace)
-        (jdbc/delete! @st/state :resources ["label = ?" idspace])
-        (jdbc/insert! @st/state :resources res)))))
+    (when 
+      (empty? 
+        (st/query {:select [:*] 
+                   :from [:resources] 
+                   :where [:= :label idspace]}))
+      (jdbc/insert! @st/state :resources res))))
 
 (defn init-dir!
   "Given a string path to a directory, create the directory and any parent 
@@ -171,7 +168,8 @@
 
 (defn exists?
   "Given a resources directory and a resource, return true if the resource does 
-   exist, false otherwise."
+   exist, false otherwise. For local file resources with multiple paths, check
+   that all files exist."
   [dir resource]
   (case (:type resource)
     :direct-link (link-resource-exists? dir resource)
@@ -183,10 +181,9 @@
           file (io/as-file (str dir "/" fname))]
       (.exists file))
     :local-file
-    (let [file (io/as-file (:path resource))]
-      (if (.exists file)
-        true
-        false))))
+    (let [paths (or (:paths resource) (list (:path resource)))
+          fs (map #(io/as-file %) paths)]
+      (every? true? (map #(.exists %) fs)))))
 
 ;; INIT RESOURCES
 
@@ -205,10 +202,12 @@
       (spit (.getAbsolutePath file) (slurp (last (:redirs response))))
       ; then return the (probably) updated resource map
       (if (:etag response)
-        (assoc resource :etag (:etag response))
+        (assoc resource :etag (:etag response) :path (.getAbsolutePath file))
         (if (:last-modified response)
-          (assoc resource :last-modified (:last-modified response))
-          resource)))))
+          (assoc resource 
+            :last-modified (:last-modified response) 
+            :path (.getAbsolutePath file))
+          (assoc resource :path (.getAbsolutePath file)))))))
 
 (defn get-link-resource!
   "Given a resources directory and a :direct-link resource, get the content from 
@@ -283,6 +282,8 @@
    the resource to the directory."
   [dir resource]
   (let [type (:type resource)]
+    (when (not (= type :local-file))
+      (println "GET" (:idspace resource)))
     (case type
       ; error when local file does not exist
       :local-file
@@ -292,7 +293,7 @@
             "Cannot configure resource '"
             (:idspace resource)
             "'\nCAUSE: "
-            (:path resource)
+            (or (:paths resource) (:path resource))
             " does not exist"))
         (System/exit 1))
       ; anything else should be fetched
@@ -410,89 +411,6 @@
       []
       resources)))
 
-;; MAIN CONFIG METHODS
-
-(defn update-resources-and-config
-  "Given the dereferenced application state and the path to the configuration 
-   file, configure the resources for the application and write any updates to 
-   the configuration file. Return the state with any updates to the resources."
-  [state config]
-  (let [resources (update-resources state)]
-    (update-config! config resources)
-    (assoc state :resources resources)))
-
-;; MOVE RESOURCES TO ONTOLOGY DIRECTORY
-
-(defn copy-file!
-  "Given a source file and a target file (in KN format),
-   copy the source file to the target file in knotation format. 
-   Return the path to the new file on success, nil on failure."
-  [src-file tgt-file]
-  (let [out-file (io/as-file tgt-file)]
-    (if (s/ends-with? src-file ".kn")
-      ; if the src file is already in knotation,
-      ; just copy it to the destination
-      (-> src-file 
-          io/as-file
-          (io/copy out-file))
-      ; otherwise, we need to convert to kn
-      (kn/render-path :kn nil (kn/read-path nil nil src-file) out-file))
-    (if-not (.exists out-file)
-      ; if the file does not exist after copying/converting,
-      ; throw an error
-      (do
-        (println (str "ERROR: Unable to copy " src-file " to " tgt-file))
-        (System/exit 1))
-      ; otherwise, return the path to the target file
-      tgt-file)))
-
-(defn copy-git-resources
-  "Given an :obo-github-repo resource, a source directory to copy resources 
-   from, and a target directory to copy resources to, copy each resource 
-   specified by the :paths key, ensuring they are in KN format."
-  [{:keys [:paths :idspace] :as resource} src-dir tgt-dir]
-  (doseq [p paths]
-    (let [src-file (str src-dir "/" p)
-          tgt-file (str tgt-dir "/" (-> p (s/split #"\." -1) first) ".kn")]
-      (copy-file! src-file tgt-file))))
-
-(defn copy-resource
-  "Given a resource, a source directory to copy from, and a target directory to 
-   copy to, copy the resource to the target in kn format. Return the path to the
-   new file on success, nil on failure."
-  [resource src-dir tgt-dir]
-  (let [fname (->> resource :idspace s/lower-case)
-        tgt-file (str tgt-dir "/" fname ".kn")]
-    (case (:type resource)
-      :local-file
-      (copy-file! (:path resource) tgt-file)
-      :obo-github-repo 
-      (copy-git-resources resource src-dir tgt-dir)
-      :obo-published-owl 
-      (copy-file! (str src-dir "/" fname ".owl") tgt-file)
-      :direct-link
-      (copy-file! (str src-dir "/" fname ".owl") tgt-file))))
-
-(defn copy-resources
-  "Given the dereferenced application state, convert any ontology files in the 
-   resources directory to knotation and move them to the ontology directory. 
-   Return a collection of the paths to the new files (if they were successfully
-   copied)."
-  [state]
-  (let [resources (:resources state)
-        project-dir (if (s/ends-with? (:absolute-dir state) "/")
-                      (:absolute-dir state)
-                      (str (:absolute-dir state) "/"))
-        src-dir (str project-dir "resources")
-        tgt-dir (str project-dir "ontology")]
-    (init-dir! tgt-dir)
-    (remove nil?
-      (reduce
-        (fn [coll resource]
-          (conj coll (copy-resource resource src-dir tgt-dir)))
-        []
-        resources))))
-
 ;; DO EVERYTHING
 
 (defn resources!
@@ -500,5 +418,6 @@
    ontology directory in knotation format. Update the state with any changes to 
    the resources. Return a collection of the new ontology paths."
   [config]
-  (reset! st/state (update-resources-and-config @st/state config))
-  (copy-resources @st/state))
+  (let [resources (update-resources @st/state)]
+    (update-config! config resources)
+    (reset! st/state (assoc @st/state :resources resources))))

--- a/src/com/knocean/knode/resources.clj
+++ b/src/com/knocean/knode/resources.clj
@@ -38,19 +38,22 @@
 
 (defn insert!
   "Given a resource entry, add the resource to the 'resources' table. If a 
-   resource with the same label (idspace) already exists, add the states
-   to the existing resource."
+   resource with the same label (idspace) already exists, delete the old
+   resource entry and add the new entry."
   [{:keys [:idspace :label :title :description :homepage] :as resource}]
   (let [res {:label idspace
              :title (or title idspace)
              :description (or description "")
              :homepage (or homepage "")}]
-    (when 
+    (if 
       (empty? 
         (st/query {:select [:*] 
                    :from [:resources] 
                    :where [:= :label idspace]}))
-      (jdbc/insert! @st/state :resources res))))
+      (jdbc/insert! @st/state :resources res)
+      (do
+        (jdbc/delete! @st/state :resources ["label = ?" idspace])
+        (jdbc/insert! @st/state :resource res)))))
 
 (defn init-dir!
   "Given a string path to a directory, create the directory and any parent 

--- a/test/com/knocean/knode/pages/resources_test.clj
+++ b/test/com/knocean/knode/pages/resources_test.clj
@@ -35,6 +35,7 @@
        st/configure
        (reset! state))
   (loader/load-resource "ex" ["test/example/context.kn" "test/example/content.kn"])
+  (jdbc/delete! @state "resources" ["label = ?" "ex"])
   (jdbc/insert! @state "resources" example-resource))
 
 (defn example-state-fixture


### PR DESCRIPTION
* Added `:paths [...]` option for local resources
* Fixed how remote resource paths were being handled
* Removed copying methods (originally needed when all resources needed to be in kn format)
* Added details to README