### PR TITLE
Fix error where tables are created twice

### DIFF
--- a/src/com/knocean/knode/resources.clj
+++ b/src/com/knocean/knode/resources.clj
@@ -53,7 +53,7 @@
       (jdbc/insert! @st/state :resources res)
       (do
         (jdbc/delete! @st/state :resources ["label = ?" idspace])
-        (jdbc/insert! @st/state :resource res)))))
+        (jdbc/insert! @st/state :resources res)))))
 
 (defn init-dir!
   "Given a string path to a directory, create the directory and any parent 


### PR DESCRIPTION
A table is created after it already has been, resulting in the error:
```
[SQLITE_ERROR] SQL error or missing database (table states already exists)
```

This fix divides up the `create-tables` method so that not both the tables are created at the same time and `load-resource` can properly check if either table exists.

`create-tables` is still used in `cli.clj` for the DB tasks.